### PR TITLE
refactor: add FirestoreTimestampType union and typed exports for API …

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "Running lint..."
+deno task lint

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,6 +1,10 @@
 name: Release & Publish
 
 on:
+  pull_request:
+    branches:
+      - main
+      - beta
   push:
     branches:
       - main
@@ -31,6 +35,7 @@ jobs:
         run: deno test tests/
 
   release:
+    if: github.event_name == 'push'
     needs: ci
     runs-on: ubuntu-latest
     permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Shared Zod schemas for CFS Firestore collections, published to JSR as `@cfs/sche
 ## Setup
 
 - **Deno** runtime
-- `deno install` — install dependencies
+- `deno task setup` — install dependencies and enable git hooks
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,10 @@ This package uses Zod 4 (`jsr:@zod/zod@^4`), not Zod 3. Key differences from v3:
 
 Each schema file exports: Zod schema object, TypeScript interface, and input schemas (where applicable).
 
+### UID property naming
+
+Any `uid` property should be named either `uid` (for the document's own user ID) or `uid_{descriptor}` (e.g., `uid_owner`, `uid_creator`) when referencing another user.
+
 ### Document vs input schemas
 
 - **Document schemas** (`ContactSchema`, `OrganizationSchema`) — full Firestore document shape, use `z.strictObject()`

--- a/deno.json
+++ b/deno.json
@@ -35,7 +35,8 @@
   "tasks": {
     "test": "deno test --allow-read tests/",
     "lint": "deno lint",
-    "check": "deno check src/mod.ts src/typesense/mod.ts"
+    "check": "deno check src/mod.ts src/typesense/mod.ts",
+    "setup": "deno install && git config core.hooksPath .githooks"
   },
   "imports": {
     "zod": "jsr:@zod/zod@^4",

--- a/src/booking.ts
+++ b/src/booking.ts
@@ -8,6 +8,7 @@ import {
   ComponentTypeEnum,
   type ComponentTypeType,
   FirestoreTimestamp,
+  type FirestoreTimestampType,
   NoteEntry,
   type NoteEntryType,
 } from "./common.ts";
@@ -65,13 +66,13 @@ export interface Booking {
   };
   dates: {
     start: string;
-    start_fs: unknown;
+    start_fs: FirestoreTimestampType;
     end: string | null;
-    end_fs: unknown;
+    end_fs: FirestoreTimestampType | null;
     charge_start: string;
-    charge_start_fs: unknown;
+    charge_start_fs: FirestoreTimestampType;
     charge_end: string | null;
-    charge_end_fs: unknown;
+    charge_end_fs: FirestoreTimestampType | null;
   };
   destinations: {
     delivery: BookingDestinationRef | null;
@@ -86,8 +87,8 @@ export interface Booking {
   query_by_uid_store: string[];
   uid_destination_delivery: string;
   uid_destination_collection: string;
-  created_at: unknown;
-  updated_at: unknown;
+  created_at: FirestoreTimestampType;
+  updated_at: FirestoreTimestampType;
 }
 
 const BookingDestinationRefSchema: z.ZodType<BookingDestinationRef> = z.strictObject({
@@ -140,11 +141,11 @@ export const BookingSchema: z.ZodType<Booking> = z.strictObject({
     start: z.string(),
     start_fs: FirestoreTimestamp,
     end: z.string().nullable(),
-    end_fs: FirestoreTimestamp,
+    end_fs: FirestoreTimestamp.nullable(),
     charge_start: z.string(),
     charge_start_fs: FirestoreTimestamp,
     charge_end: z.string().nullable(),
-    charge_end_fs: FirestoreTimestamp,
+    charge_end_fs: FirestoreTimestamp.nullable(),
   }),
   destinations: z.strictObject({
     delivery: BookingDestinationRefSchema.nullable(),

--- a/src/cache-geocodes.ts
+++ b/src/cache-geocodes.ts
@@ -2,7 +2,7 @@
  * CacheGeocodes document schema — Firestore collection: cache-geocodes
  */
 import { z } from "zod";
-import { Coordinates, type CoordinatesType, FirestoreTimestamp } from "./common.ts";
+import { Coordinates, type CoordinatesType, FirestoreTimestamp, type FirestoreTimestampType } from "./common.ts";
 
 export interface CacheGeocodesAddress {
   street?: string;
@@ -19,8 +19,8 @@ export interface CacheGeocodes {
   coordinates: CoordinatesType | null;
   mapbox_id: string;
   address: CacheGeocodesAddress;
-  created_at?: unknown;
-  expiresAt?: unknown;
+  created_at?: FirestoreTimestampType;
+  expiresAt?: FirestoreTimestampType;
 }
 
 export const CacheGeocodesSchema: z.ZodType<CacheGeocodes> = z.strictObject({

--- a/src/chart-of-accounts.ts
+++ b/src/chart-of-accounts.ts
@@ -2,7 +2,7 @@
  * ChartOfAccounts document schema — Firestore collection: chart-of-accounts
  */
 import { z } from "zod";
-import { TimestampFields } from "./common.ts";
+import { type FirestoreTimestampType, TimestampFields } from "./common.ts";
 
 const COA_CODES = [
   "2210", "2800",
@@ -32,8 +32,8 @@ export interface ChartOfAccounts {
   description?: string;
   default_tax_profile: string;
   updated_by: string;
-  created_at?: unknown;
-  updated_at?: unknown;
+  created_at?: FirestoreTimestampType;
+  updated_at?: FirestoreTimestampType;
 }
 
 export const ChartOfAccountsSchema: z.ZodType<ChartOfAccounts> = z.strictObject({

--- a/src/common.ts
+++ b/src/common.ts
@@ -4,17 +4,36 @@
 import { z } from "zod";
 
 /**
+ * Structural interfaces for Firestore Timestamp and FieldValue.
+ * Expressed structurally so the schemas package has no firebase-admin dependency.
+ */
+export interface FirestoreTimestampValue {
+  toMillis(): number;
+  toDate(): Date;
+  seconds: number;
+  nanoseconds: number;
+}
+
+export interface FirestoreFieldValue {
+  isEqual(other: FirestoreFieldValue): boolean;
+}
+
+export type FirestoreTimestampType = FirestoreTimestampValue | FirestoreFieldValue;
+
+/**
  * Firestore server timestamp — passthrough since it's a Firestore
  * FieldValue at write time and a Firestore Timestamp at read time.
  */
-export const FirestoreTimestamp: z.ZodType<unknown> = z.any();
+export const FirestoreTimestamp: z.ZodType<FirestoreTimestampType> = z.custom<FirestoreTimestampType>(
+  (val) => val === undefined || val === null || typeof val === "object",
+);
 
 /**
  * Standard timestamp fields present on most documents.
  */
 export const TimestampFields: {
-  created_at: z.ZodType<unknown>;
-  updated_at: z.ZodType<unknown>;
+  created_at: z.ZodType<FirestoreTimestampType>;
+  updated_at: z.ZodType<FirestoreTimestampType>;
 } = {
   created_at: FirestoreTimestamp,
   updated_at: FirestoreTimestamp,
@@ -81,7 +100,7 @@ export const UidNameRef: z.ZodType<UidNameRefType> = z.strictObject({
  */
 export interface NoteEntryType {
   note: string;
-  updated_at?: unknown;
+  updated_at?: FirestoreTimestampType;
   updated_by?: string;
 }
 

--- a/src/contact.ts
+++ b/src/contact.ts
@@ -2,7 +2,7 @@
  * Contact document schema — Firestore collection: contacts
  */
 import { z } from "zod";
-import { Email, Phone, TimestampFields } from "./common.ts";
+import { Email, type FirestoreTimestampType, Phone, TimestampFields } from "./common.ts";
 
 /**
  * Organization reference embedded in a contact document.
@@ -28,9 +28,10 @@ export interface Contact {
   phones: string[];
   organizations: ContactOrganizationType[];
   query_by_organizations: string[];
+  uid_user?: string;
   updated_by?: string;
-  created_at?: unknown;
-  updated_at?: unknown;
+  created_at?: FirestoreTimestampType;
+  updated_at?: FirestoreTimestampType;
 }
 
 export const ContactSchema: z.ZodType<Contact> = z.strictObject({
@@ -41,6 +42,7 @@ export const ContactSchema: z.ZodType<Contact> = z.strictObject({
   phones: z.array(Phone).default([]),
   organizations: z.array(ContactOrganization).default([]),
   query_by_organizations: z.array(z.string()).default([]),
+  uid_user: z.string().optional(),
   updated_by: z.string().optional(),
   ...TimestampFields,
 }).meta({

--- a/src/destination.ts
+++ b/src/destination.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import {
   Address,
   type AddressType,
+  type FirestoreTimestampType,
   TimestampFields,
   UidNameRef,
   type UidNameRefType,
@@ -20,8 +21,8 @@ export interface Destination {
   query_by_products?: string[];
   contacts?: UidNameRefType[];
   query_by_contacts?: string[];
-  created_at?: unknown;
-  updated_at?: unknown;
+  created_at?: FirestoreTimestampType;
+  updated_at?: FirestoreTimestampType;
 }
 
 export const DestinationSchema: z.ZodType<Destination> = z.strictObject({

--- a/src/email-verification.ts
+++ b/src/email-verification.ts
@@ -3,17 +3,18 @@
  * Tokens are single-use with a 24-hour expiry.
  */
 import { z } from "zod";
+import { FirestoreTimestamp, type FirestoreTimestampType } from "./common.ts";
 
 export interface EmailVerification {
   user_id: string;
   email: string;
-  expiresAt: unknown;
+  expiresAt: FirestoreTimestampType;
   created_at: number;
 }
 
 export const EmailVerificationSchema: z.ZodType<EmailVerification> = z.strictObject({
   user_id: z.string().min(1),
   email: z.string().email(),
-  expiresAt: z.any(),
+  expiresAt: FirestoreTimestamp,
   created_at: z.number(),
 }).meta({ title: "Email Verification", collection: "email-verifications" });

--- a/src/holiday-dates.ts
+++ b/src/holiday-dates.ts
@@ -2,17 +2,17 @@
  * HolidayDates document schema — Firestore collection: holiday-dates
  */
 import { z } from "zod";
-import { FirestoreTimestamp } from "./common.ts";
+import { FirestoreTimestamp, type FirestoreTimestampType } from "./common.ts";
 
 export interface HolidayDates {
   uid: string;
   uid_holiday: string;
   date: string;
-  date_fs?: unknown;
+  date_fs?: FirestoreTimestampType;
   name: string;
   type: "fixed" | "variable";
-  created_at?: unknown;
-  updated_at?: unknown;
+  created_at?: FirestoreTimestampType;
+  updated_at?: FirestoreTimestampType;
 }
 
 export const HolidayDatesSchema: z.ZodType<HolidayDates> = z.strictObject({

--- a/src/inventory-ledger.ts
+++ b/src/inventory-ledger.ts
@@ -4,6 +4,7 @@
 import { z } from "zod";
 import {
   FirestoreTimestamp,
+  type FirestoreTimestampType,
   NoteEntry,
   type NoteEntryType,
   ProductTypeEnum,
@@ -49,8 +50,8 @@ export interface InventoryLedger {
   };
   store_breakdown: InventoryLedgerStore[];
   query_by_uid_store: string[];
-  created_at: unknown;
-  updated_at: unknown;
+  created_at: FirestoreTimestampType;
+  updated_at: FirestoreTimestampType;
 }
 
 const InventoryLedgerLocationSchema: z.ZodType<InventoryLedgerLocation> = z.strictObject({

--- a/src/invoice.ts
+++ b/src/invoice.ts
@@ -7,6 +7,7 @@ import {
   type AddressType,
   COARevenueEnum,
   FirestoreTimestamp,
+  type FirestoreTimestampType,
   ItemTaxProfileEnum,
   type ItemTaxProfileType,
   TaxProfileEnum,
@@ -15,11 +16,11 @@ import {
 } from "./common.ts";
 
 const INVOICE_STATUSES = ["draft", "issued", "paid", "voided"] as const;
-type InvoiceStatusType = typeof INVOICE_STATUSES[number];
+export type InvoiceStatusType = typeof INVOICE_STATUSES[number];
 const InvoiceStatus: z.ZodType<InvoiceStatusType> = z.enum(INVOICE_STATUSES);
 
 const INVOICE_ITEM_TYPES = ["rental", "sale", "service", "surcharge", "replacement", "group"] as const;
-type InvoiceItemTypeType = typeof INVOICE_ITEM_TYPES[number];
+export type InvoiceItemTypeType = typeof INVOICE_ITEM_TYPES[number];
 
 export interface InvoiceItemPrice {
   base: number;
@@ -52,9 +53,9 @@ export interface Invoice {
   status: InvoiceStatusType;
   tax_profile: TaxProfileType;
   date: string;
-  date_fs?: unknown;
+  date_fs?: FirestoreTimestampType;
   due_date?: string;
-  due_date_fs?: unknown;
+  due_date_fs?: FirestoreTimestampType;
   subject?: string | null;
   reference?: string | null;
   external_notes?: string | null;
@@ -71,8 +72,8 @@ export interface Invoice {
   items_consolidated: Record<string, InvoiceItem>;
   xero_id: string | null;
   updated_by: string;
-  created_at?: unknown;
-  updated_at?: unknown;
+  created_at?: FirestoreTimestampType;
+  updated_at?: FirestoreTimestampType;
 }
 
 const InvoiceItemSchema: z.ZodType<InvoiceItem> = z.strictObject({

--- a/src/location-type.ts
+++ b/src/location-type.ts
@@ -2,7 +2,7 @@
  * LocationType document schema — Firestore collection: location-types
  */
 import { z } from "zod";
-import { FirestoreTimestamp } from "./common.ts";
+import { FirestoreTimestamp, type FirestoreTimestampType } from "./common.ts";
 
 export interface LocationTypeProductCapacity {
   uid: string;
@@ -23,8 +23,8 @@ export interface LocationType {
   query_by_product_capacities?: string[];
   dimensions?: LocationTypeDimensions | null;
   active: boolean;
-  created_at?: unknown;
-  updated_at?: unknown;
+  created_at?: FirestoreTimestampType;
+  updated_at?: FirestoreTimestampType;
 }
 
 export const LocationTypeSchema: z.ZodType<LocationType> = z.strictObject({

--- a/src/location.ts
+++ b/src/location.ts
@@ -2,7 +2,7 @@
  * Location document schema — Firestore collection: locations
  */
 import { z } from "zod";
-import { FirestoreTimestamp } from "./common.ts";
+import { FirestoreTimestamp, type FirestoreTimestampType } from "./common.ts";
 
 export interface LocationProductCapacity {
   uid: string;
@@ -28,8 +28,8 @@ export interface Location {
   active: boolean;
   products: LocationProduct[];
   query_by_products: string[];
-  created_at: unknown;
-  updated_at: unknown;
+  created_at: FirestoreTimestampType;
+  updated_at: FirestoreTimestampType;
 }
 
 export const LocationSchema: z.ZodType<Location> = z.strictObject({

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -79,6 +79,10 @@ export {
   type DocDestinationContactType,
   type OrderItemType,
   type ItemPriceType,
+  OrderDocDates,
+  OrderDocItem,
+  type OrderDocDatesType,
+  type OrderDocItemType,
 } from "./order.ts";
 
 export {
@@ -112,6 +116,9 @@ export {
   OOSReasonEnum,
   type AddressType,
   type CoordinatesType,
+  type FirestoreTimestampType,
+  type FirestoreTimestampValue,
+  type FirestoreFieldValue,
   type UidNameRefType,
   type NoteEntryType,
   type ProductTypeType,
@@ -236,6 +243,8 @@ export {
   type Invoice,
   type InvoiceItem,
   type InvoiceItemPrice,
+  type InvoiceItemTypeType,
+  type InvoiceStatusType,
 } from "./invoice.ts";
 
 export {
@@ -247,6 +256,8 @@ export {
 
 export {
   TransactionSchema,
+  TransactionStoreSchema,
+  TransactionStoreLocationSchema,
   TRANSACTION_TYPES,
   getTransactionMultiplier,
   CreateTransactionInput,
@@ -296,6 +307,45 @@ export {
   type TypesenseConfig,
   type TypesenseConfigReindexStats,
 } from "./typesense-config.ts";
+
+// ── Union of all Firestore document types ───────────────────────────
+
+import type { Booking } from "./booking.ts";
+import type { CacheGeocodes } from "./cache-geocodes.ts";
+import type { ChartOfAccounts } from "./chart-of-accounts.ts";
+import type { Contact } from "./contact.ts";
+import type { Destination as DestinationDocType } from "./destination.ts";
+import type { EmailVerification } from "./email-verification.ts";
+import type { HolidayDates } from "./holiday-dates.ts";
+import type { InventoryLedger } from "./inventory-ledger.ts";
+import type { Invoice } from "./invoice.ts";
+import type { Location } from "./location.ts";
+import type { LocationType } from "./location-type.ts";
+import type { Order } from "./order.ts";
+import type { Organization } from "./organization.ts";
+import type { OutOfServiceRecord } from "./out-of-service-record.ts";
+import type { PasswordReset } from "./password-reset.ts";
+import type { Product } from "./product.ts";
+import type { PublicStockSummary } from "./public-stock-summary.ts";
+import type { RateLimit } from "./rate-limit.ts";
+import type { Session } from "./session.ts";
+import type { StockSummary } from "./stock-summary.ts";
+import type { Store } from "./store.ts";
+import type { Tag } from "./tag.ts";
+import type { TrackingCategory } from "./tracking-category.ts";
+import type { Transaction } from "./transaction.ts";
+import type { TypesenseConfig } from "./typesense-config.ts";
+import type { User } from "./user.ts";
+import type { WebshopProduct } from "./webshop-product.ts";
+
+/** Union of all Firestore document types. Use with validateBeforeWrite. */
+export type SchemaDocType =
+  | Booking | CacheGeocodes | ChartOfAccounts | Contact | DestinationDocType
+  | EmailVerification | HolidayDates | InventoryLedger | Invoice | Location
+  | LocationType | Order | Organization | OutOfServiceRecord | PasswordReset
+  | Product | PublicStockSummary | RateLimit | Session | StockSummary
+  | Store | Tag | TrackingCategory | Transaction | TypesenseConfig | User
+  | WebshopProduct;
 
 // ── Schema record keyed by collection name ─────────────────────────
 

--- a/src/order.ts
+++ b/src/order.ts
@@ -288,7 +288,19 @@ export const UpdateOrderInput: z.ZodType<UpdateOrderInputType> = z.object({
 /**
  * Line item price in the full order document (all fields required after server compute).
  */
-const OrderDocItemPrice = z.strictObject({
+interface OrderDocItemPriceType {
+  base: number;
+  chargeable_days: number | null;
+  discount_amount: number;
+  discount_percent: number;
+  formula: PriceFormulaType;
+  subtotal: number;
+  tax_amount: number;
+  tax_profile: ItemTaxProfileType;
+  total: number;
+}
+
+const OrderDocItemPrice: z.ZodType<OrderDocItemPriceType> = z.strictObject({
   base: z.number().default(0),
   chargeable_days: z.number().int().nullable().default(null),
   discount_amount: z.number().default(0),
@@ -301,7 +313,25 @@ const OrderDocItemPrice = z.strictObject({
 });
 
 /** Line item in the full order document. */
-const OrderDocLineItem = z.strictObject({
+interface OrderDocLineItemType {
+  uid: string;
+  type: DocLineItemTypeType;
+  name: string;
+  description: string;
+  quantity: number;
+  price?: OrderDocItemPriceType;
+  stock_method?: StockMethodType;
+  order_number?: number;
+  uid_order?: string;
+  uid_component_of?: string | null;
+  inclusion_type?: "default" | "mandatory" | "optional" | null;
+  zero_priced?: boolean | null;
+  crms_id?: number | null;
+  uid_delivery?: string | null;
+  uid_collection?: string | null;
+}
+
+const OrderDocLineItem: z.ZodType<OrderDocLineItemType> = z.strictObject({
   uid: z.string(),
   type: z.enum(DOC_LINE_ITEM_TYPES),
   name: z.string().min(1).max(100),
@@ -341,7 +371,14 @@ export const OrderDocDestinationItem: z.ZodType<OrderDocDestinationItemType> = z
 });
 
 /** Group divider in items array. */
-const OrderDocGroupItem = z.strictObject({
+interface OrderDocGroupItemType {
+  uid: string;
+  type: "group";
+  name: string;
+  description: string;
+}
+
+const OrderDocGroupItem: z.ZodType<OrderDocGroupItemType> = z.strictObject({
   uid: z.uuid(),
   type: z.literal("group"),
   name: z.string().min(1).max(100),
@@ -349,14 +386,29 @@ const OrderDocGroupItem = z.strictObject({
 });
 
 /** Union of all item types in the document. */
-export const OrderDocItem = z.union([
+export const OrderDocItem: z.ZodType<OrderDocLineItemType | OrderDocDestinationItemType | OrderDocGroupItemType> = z.union([
   OrderDocLineItem,
   OrderDocDestinationItem,
   OrderDocGroupItem,
 ]);
 
 /** Order dates with Firestore timestamp companions. */
-export const OrderDocDates = z.strictObject({
+export interface OrderDocDatesType {
+  delivery_start: string;
+  delivery_start_fs: FirestoreTimestampType;
+  delivery_end: string;
+  delivery_end_fs: FirestoreTimestampType;
+  collection_start: string;
+  collection_start_fs: FirestoreTimestampType;
+  collection_end: string;
+  collection_end_fs: FirestoreTimestampType;
+  charge_start: string;
+  charge_start_fs: FirestoreTimestampType;
+  charge_end: string;
+  charge_end_fs: FirestoreTimestampType;
+}
+
+export const OrderDocDates: z.ZodType<OrderDocDatesType> = z.strictObject({
   delivery_start: z.string().default(""),
   delivery_start_fs: FirestoreTimestamp,
   delivery_end: z.string().default(""),
@@ -371,8 +423,7 @@ export const OrderDocDates = z.strictObject({
   charge_end_fs: FirestoreTimestamp,
 });
 
-export type OrderDocDatesType = z.infer<typeof OrderDocDates>;
-export type OrderDocItemType = z.infer<typeof OrderDocItem>;
+export type OrderDocItemType = OrderDocLineItemType | OrderDocDestinationItemType | OrderDocGroupItemType;
 
 /** Denormalized organization snapshot on the order document. */
 const OrderDocOrganization = z.strictObject({

--- a/src/order.ts
+++ b/src/order.ts
@@ -6,6 +6,7 @@ import {
   Address,
   type AddressType,
   FirestoreTimestamp,
+  type FirestoreTimestampType,
   InclusionTypeEnum,
   type InclusionTypeType,
   ItemTaxProfileEnum,
@@ -348,14 +349,14 @@ const OrderDocGroupItem = z.strictObject({
 });
 
 /** Union of all item types in the document. */
-const OrderDocItem = z.union([
+export const OrderDocItem = z.union([
   OrderDocLineItem,
   OrderDocDestinationItem,
   OrderDocGroupItem,
 ]);
 
 /** Order dates with Firestore timestamp companions. */
-const OrderDocDates = z.strictObject({
+export const OrderDocDates = z.strictObject({
   delivery_start: z.string().default(""),
   delivery_start_fs: FirestoreTimestamp,
   delivery_end: z.string().default(""),
@@ -369,6 +370,9 @@ const OrderDocDates = z.strictObject({
   charge_end: z.string().default(""),
   charge_end_fs: FirestoreTimestamp,
 });
+
+export type OrderDocDatesType = z.infer<typeof OrderDocDates>;
+export type OrderDocItemType = z.infer<typeof OrderDocItem>;
 
 /** Denormalized organization snapshot on the order document. */
 const OrderDocOrganization = z.strictObject({
@@ -402,9 +406,9 @@ export interface Order {
     xero_id?: string | null;
     billing_address?: AddressType | null;
   };
-  dates: Record<string, unknown>;
+  dates: OrderDocDatesType;
   destinations: DocDestinationType[];
-  items: Record<string, unknown>[];
+  items: OrderDocItemType[];
   tax_profile: TaxProfileType;
   totals: { discount_amount: number; subtotal: number; taxes: Record<string, number>; total: number };
   query_by_items: string[];
@@ -416,8 +420,8 @@ export interface Order {
   notes?: string;
   customer_collecting?: boolean;
   customer_returning?: boolean;
-  created_at?: unknown;
-  updated_at?: unknown;
+  created_at?: FirestoreTimestampType;
+  updated_at?: FirestoreTimestampType;
 }
 
 export const OrderSchema: z.ZodType<Order> = z.strictObject({

--- a/src/organization.ts
+++ b/src/organization.ts
@@ -6,6 +6,8 @@ import {
   Address,
   type AddressType,
   Email,
+  FirestoreTimestamp,
+  type FirestoreTimestampType,
   Phone,
   TaxProfileEnum,
   type TaxProfileType,
@@ -42,10 +44,10 @@ export interface Organization {
   billing_address: AddressType | null;
   contacts: OrganizationContactType[];
   query_by_contacts: string[];
-  last_order?: unknown;
+  last_order?: FirestoreTimestampType | null;
   updated_by?: string;
-  created_at?: unknown;
-  updated_at?: unknown;
+  created_at?: FirestoreTimestampType;
+  updated_at?: FirestoreTimestampType;
 }
 
 export const OrganizationSchema: z.ZodType<Organization> = z.strictObject({
@@ -60,7 +62,7 @@ export const OrganizationSchema: z.ZodType<Organization> = z.strictObject({
   billing_address: Address,
   contacts: z.array(OrganizationContact).default([]),
   query_by_contacts: z.array(z.string()).default([]),
-  last_order: z.any().optional(),
+  last_order: FirestoreTimestamp.nullable().optional(),
   updated_by: z.string().optional(),
   ...TimestampFields,
 }).meta({

--- a/src/out-of-service-record.ts
+++ b/src/out-of-service-record.ts
@@ -4,6 +4,7 @@
 import { z } from "zod";
 import {
   FirestoreTimestamp,
+  type FirestoreTimestampType,
   NoteEntry,
   type NoteEntryType,
   OOSReasonEnum,
@@ -33,7 +34,7 @@ export interface OOSTransaction {
   crms_quarantine_id?: number | null;
   crms_stock_level_id?: number | null;
   date: string;
-  date_fs?: unknown;
+  date_fs?: FirestoreTimestampType;
   notes?: string | null;
   out_of_service_uid: string;
   quantity: number;
@@ -56,9 +57,9 @@ export interface OutOfServiceRecord {
   quantity_write_off: number;
   complete?: boolean;
   date_start: string;
-  date_start_fs?: unknown;
+  date_start_fs?: FirestoreTimestampType;
   date_end?: string;
-  date_end_fs?: unknown;
+  date_end_fs?: FirestoreTimestampType;
   crms_id?: number | null;
   crms_stock_level_id?: number | null;
   source: OOSSource;
@@ -67,8 +68,8 @@ export interface OutOfServiceRecord {
   query_by_uid_store?: string[];
   notes?: NoteEntryType[];
   transactions?: OOSTransaction[];
-  created_at?: unknown;
-  updated_at?: unknown;
+  created_at?: FirestoreTimestampType;
+  updated_at?: FirestoreTimestampType;
 }
 
 const OOSStoreLocationSchema: z.ZodType<OOSStoreLocation> = z.strictObject({

--- a/src/password-reset.ts
+++ b/src/password-reset.ts
@@ -3,17 +3,18 @@
  * Tokens are single-use with a 1-hour expiry.
  */
 import { z } from "zod";
+import { FirestoreTimestamp, type FirestoreTimestampType } from "./common.ts";
 
 export interface PasswordReset {
   user_id: string;
   email: string;
-  expiresAt: unknown;
+  expiresAt: FirestoreTimestampType;
   created_at: number;
 }
 
 export const PasswordResetSchema: z.ZodType<PasswordReset> = z.strictObject({
   user_id: z.string().min(1),
   email: z.string().email(),
-  expiresAt: z.any(),
+  expiresAt: FirestoreTimestamp,
   created_at: z.number(),
 }).meta({ title: "Password Reset", collection: "password-resets" });

--- a/src/product.ts
+++ b/src/product.ts
@@ -2,10 +2,12 @@
  * Product document schema — Firestore collection: products
  */
 import { z } from "zod";
+import { type TransactionStore, TransactionStoreSchema } from "./transaction.ts";
 import {
   COARevenueEnum,
   ComponentTypeEnum,
   type ComponentTypeType,
+  type FirestoreTimestampType,
   InclusionTypeEnum,
   type InclusionTypeType,
   ItemTaxProfileEnum,
@@ -100,11 +102,12 @@ export interface Product {
   uid_linked_replacement?: string;
   uid_tracking_category?: string;
   webshop: ProductWebshop;
+  images?: string[];
   xero_id?: string | null;
   xero_tracking_option_id?: string;
   updated_by?: string;
-  created_at?: unknown;
-  updated_at?: unknown;
+  created_at?: FirestoreTimestampType;
+  updated_at?: FirestoreTimestampType;
 }
 
 const ComponentSchema: z.ZodType<ProductComponent> = z.strictObject({
@@ -175,6 +178,7 @@ export const ProductSchema: z.ZodType<Product> = z.strictObject({
     available: z.boolean().default(false),
     description: z.string().nullable().optional(),
   }),
+  images: z.array(z.string()).optional(),
   xero_id: z.string().nullable().optional(),
   xero_tracking_option_id: z.string().optional(),
   updated_by: z.string().optional(),
@@ -214,8 +218,8 @@ export interface CreateProductInputType {
     air_un: number | null;
   };
   alternates?: Record<string, UidNameRefType>;
-  components?: Record<string, unknown>;
-  component_of?: Record<string, unknown>;
+  components?: Record<string, ProductComponent>;
+  component_of?: Record<string, ProductComponent>;
   tags?: UidNameRefType[];
   tracking_category_name?: string;
   uid_tracking_category?: string;
@@ -232,7 +236,7 @@ export interface CreateProductInputType {
     total_cost: number;
     date: string;
     reference: string;
-    stores: unknown[];
+    stores: TransactionStore[];
   };
   updated_by?: string;
 }
@@ -266,8 +270,8 @@ export const CreateProductInput: z.ZodType<CreateProductInputType> = z.object({
     air_un: z.number().nullable(),
   }).optional(),
   alternates: z.record(z.string(), UidNameRef).default({}),
-  components: z.record(z.string(), z.any()).default({}),
-  component_of: z.record(z.string(), z.any()).default({}),
+  components: z.record(z.string(), ComponentSchema).default({}),
+  component_of: z.record(z.string(), ComponentSchema).default({}),
   tags: z.array(UidNameRef).default([]),
   tracking_category_name: z.string().optional(),
   uid_tracking_category: z.string().optional(),
@@ -284,7 +288,7 @@ export const CreateProductInput: z.ZodType<CreateProductInputType> = z.object({
     total_cost: z.number(),
     date: z.string(),
     reference: z.string(),
-    stores: z.array(z.any()),
+    stores: z.array(TransactionStoreSchema),
   }).optional(),
   updated_by: z.string().optional(),
 });
@@ -317,8 +321,8 @@ export interface UpdateProductInputType {
     air_un: number | null;
   };
   alternates?: Record<string, UidNameRefType>;
-  components?: Record<string, unknown>;
-  component_of?: Record<string, unknown>;
+  components?: Record<string, ProductComponent>;
+  component_of?: Record<string, ProductComponent>;
   tags?: UidNameRefType[];
   uid_tracking_category?: string;
   uid_linked_rental?: string;
@@ -328,7 +332,8 @@ export interface UpdateProductInputType {
     description?: string | null;
   };
   updated_by?: string;
-  [key: string]: unknown;
+  // deno-lint-ignore no-explicit-any
+  [key: string]: any;
 }
 
 export const UpdateProductInput: z.ZodType<UpdateProductInputType> = z.object({
@@ -360,8 +365,8 @@ export const UpdateProductInput: z.ZodType<UpdateProductInputType> = z.object({
     air_un: z.number().nullable(),
   }).optional(),
   alternates: z.record(z.string(), UidNameRef).optional(),
-  components: z.record(z.string(), z.any()).optional(),
-  component_of: z.record(z.string(), z.any()).optional(),
+  components: z.record(z.string(), ComponentSchema).optional(),
+  component_of: z.record(z.string(), ComponentSchema).optional(),
   tags: z.array(UidNameRef).optional(),
   uid_tracking_category: z.string().optional(),
   uid_linked_rental: z.string().optional(),

--- a/src/public-stock-summary.ts
+++ b/src/public-stock-summary.ts
@@ -2,7 +2,7 @@
  * PublicStockSummary document schema — Firestore collection: public-stock-summaries
  */
 import { z } from "zod";
-import { FirestoreTimestamp, ProductTypeEnum, type ProductTypeType } from "./common.ts";
+import { FirestoreTimestamp, type FirestoreTimestampType, ProductTypeEnum, type ProductTypeType } from "./common.ts";
 
 const SUMMARY_TYPES = ["sale", "rental"] as const;
 type SummaryTypeType = typeof SUMMARY_TYPES[number];
@@ -19,16 +19,16 @@ export interface PublicStockSummary {
   type: ProductTypeType;
   dates: {
     start: string;
-    start_fs: unknown;
+    start_fs: FirestoreTimestampType;
     end: string | null;
-    end_fs: unknown;
+    end_fs: FirestoreTimestampType | null;
   };
   quantity_available: number;
   store_breakdown: PublicStockSummaryStore[];
   query_by_uid_store: string[];
-  created_at: unknown;
-  updated_at: unknown;
-  expiresAt: unknown;
+  created_at: FirestoreTimestampType;
+  updated_at: FirestoreTimestampType;
+  expiresAt: FirestoreTimestampType;
 }
 
 export const PublicStockSummarySchema: z.ZodType<PublicStockSummary> = z.strictObject({
@@ -40,7 +40,7 @@ export const PublicStockSummarySchema: z.ZodType<PublicStockSummary> = z.strictO
     start: z.string(),
     start_fs: FirestoreTimestamp,
     end: z.string().nullable(),
-    end_fs: FirestoreTimestamp,
+    end_fs: FirestoreTimestamp.nullable(),
   }),
   quantity_available: z.number(),
   store_breakdown: z.array(z.strictObject({

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -5,15 +5,16 @@
  * TTL policy on expiresAt for automatic Firestore cleanup.
  */
 import { z } from "zod";
+import { FirestoreTimestamp, type FirestoreTimestampType } from "./common.ts";
 
 export interface RateLimit {
   attempt_count: number;
   first_attempt_at: number;
-  expiresAt: unknown;
+  expiresAt: FirestoreTimestampType;
 }
 
 export const RateLimitSchema: z.ZodType<RateLimit> = z.strictObject({
   attempt_count: z.number().int().min(1),
   first_attempt_at: z.number(),
-  expiresAt: z.any(),
+  expiresAt: FirestoreTimestamp,
 }).meta({ title: "RateLimit", collection: "rate-limits" });

--- a/src/session.ts
+++ b/src/session.ts
@@ -7,6 +7,7 @@
  * - TTL policy on expiresAt for automatic Firestore cleanup
  */
 import { z } from "zod";
+import { FirestoreTimestamp, type FirestoreTimestampType } from "./common.ts";
 
 /**
  * Full session document schema (Firestore document shape).
@@ -16,7 +17,7 @@ export interface Session {
   id: string;
   user_id: string;
   anonymous: boolean;
-  expiresAt: unknown;
+  expiresAt: FirestoreTimestampType;
   created_at: number;
   user_agent: string;
 }
@@ -25,7 +26,7 @@ export const SessionSchema: z.ZodType<Session> = z.strictObject({
   id: z.string().length(40),
   user_id: z.string(),
   anonymous: z.boolean(),
-  expiresAt: z.any(),
+  expiresAt: FirestoreTimestamp,
   created_at: z.number(),
   user_agent: z.string(),
 }).meta({ title: "Session", collection: "sessions" });

--- a/src/stock-summary.ts
+++ b/src/stock-summary.ts
@@ -4,6 +4,7 @@
 import { z } from "zod";
 import {
   FirestoreTimestamp,
+  type FirestoreTimestampType,
   NoteEntry,
   type NoteEntryType,
   ProductTypeEnum,
@@ -38,9 +39,9 @@ export interface StockSummary {
   type: ProductTypeType;
   dates: {
     start: string;
-    start_fs: unknown;
+    start_fs: FirestoreTimestampType;
     end: string | null;
-    end_fs: unknown;
+    end_fs: FirestoreTimestampType | null;
   };
   bookings: Record<string, unknown>[];
   bookings_breakdown: {
@@ -65,9 +66,9 @@ export interface StockSummary {
   quantity_out_of_service: number;
   store_breakdown: StockSummaryStore[];
   query_by_uid_store: string[];
-  created_at: unknown;
-  updated_at: unknown;
-  expiresAt: unknown;
+  created_at: FirestoreTimestampType;
+  updated_at: FirestoreTimestampType;
+  expiresAt: FirestoreTimestampType;
 }
 
 const StockSummaryStoreLocationSchema: z.ZodType<StockSummaryStoreLocation> = z.strictObject({
@@ -97,7 +98,7 @@ export const StockSummarySchema: z.ZodType<StockSummary> = z.strictObject({
     start: z.string(),
     start_fs: FirestoreTimestamp,
     end: z.string().nullable(),
-    end_fs: FirestoreTimestamp,
+    end_fs: FirestoreTimestamp.nullable(),
   }),
   bookings: z.array(z.record(z.string(), z.unknown())),
   bookings_breakdown: z.strictObject({

--- a/src/store.ts
+++ b/src/store.ts
@@ -2,7 +2,7 @@
  * Store document schema — Firestore collection: stores
  */
 import { z } from "zod";
-import { TimestampFields } from "./common.ts";
+import { type FirestoreTimestampType, TimestampFields } from "./common.ts";
 
 export interface Store {
   uid: string;
@@ -10,8 +10,8 @@ export interface Store {
   default: boolean;
   crms_store_id: number;
   active: boolean;
-  created_at?: unknown;
-  updated_at?: unknown;
+  created_at?: FirestoreTimestampType;
+  updated_at?: FirestoreTimestampType;
 }
 
 export const StoreSchema: z.ZodType<Store> = z.strictObject({

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -2,23 +2,23 @@
  * Tag document schema — Firestore collection: tags
  */
 import { z } from "zod";
-import { TimestampFields, type UidNameRefType, UidNameRef } from "./common.ts";
+import { type FirestoreFieldValue, type FirestoreTimestampType, TimestampFields, type UidNameRefType, UidNameRef } from "./common.ts";
 
 export interface Tag {
   uid: string;
   name: string;
-  count?: Record<string, unknown> | number;
+  count?: Record<string, FirestoreFieldValue> | number;
   products?: UidNameRefType[];
   query_by_products?: string[];
   updated_by?: string;
-  created_at?: unknown;
-  updated_at?: unknown;
+  created_at?: FirestoreTimestampType;
+  updated_at?: FirestoreTimestampType;
 }
 
 export const TagSchema: z.ZodType<Tag> = z.strictObject({
   uid: z.string(),
   name: z.string().min(1).max(100),
-  count: z.union([z.record(z.string(), z.unknown()), z.number()]).optional(),
+  count: z.union([z.record(z.string(), z.custom<FirestoreFieldValue>()), z.number()]).optional(),
   products: z.array(UidNameRef).default([]).optional(),
   query_by_products: z.array(z.string()).default([]).optional(),
   updated_by: z.string().optional(),

--- a/src/tracking-category.ts
+++ b/src/tracking-category.ts
@@ -2,26 +2,26 @@
  * TrackingCategory document schema — Firestore collection: tracking-categories
  */
 import { z } from "zod";
-import { TimestampFields, UidNameRef, type UidNameRefType } from "./common.ts";
+import { type FirestoreFieldValue, type FirestoreTimestampType, TimestampFields, UidNameRef, type UidNameRefType } from "./common.ts";
 
 export interface TrackingCategory {
   uid: string;
   name: string;
-  count?: Record<string, unknown> | number;
+  count?: Record<string, FirestoreFieldValue> | number;
   crms_product_group_id?: number;
   crms_service_group_id?: number;
   crms_product_group_name: string;
   products: Record<string, UidNameRefType>;
   xero_tracking_option_id: string | null;
   updated_by: string;
-  created_at?: unknown;
-  updated_at?: unknown;
+  created_at?: FirestoreTimestampType;
+  updated_at?: FirestoreTimestampType;
 }
 
 export const TrackingCategorySchema: z.ZodType<TrackingCategory> = z.strictObject({
   uid: z.string(),
   name: z.string().min(1).max(100),
-  count: z.union([z.record(z.string(), z.unknown()), z.number()]).optional(),
+  count: z.union([z.record(z.string(), z.custom<FirestoreFieldValue>()), z.number()]).optional(),
   crms_product_group_id: z.number().optional(),
   crms_service_group_id: z.number().optional(),
   crms_product_group_name: z.string(),

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -2,7 +2,7 @@
  * Transaction document schema — Firestore collection: transactions
  */
 import { z } from "zod";
-import { FirestoreTimestamp, NoteEntry, type NoteEntryType } from "./common.ts";
+import { FirestoreTimestamp, type FirestoreTimestampType, NoteEntry, type NoteEntryType } from "./common.ts";
 
 export const TRANSACTION_TYPES = [
   "purchase", "find", "make", "opening_balance", "adjustment_increase",
@@ -67,7 +67,7 @@ export interface Transaction {
   unit_cost: number;
   unit_costs: number[];
   date: string;
-  date_fs: unknown;
+  date_fs: FirestoreTimestampType;
   reference: string;
   source: TransactionSource;
   stores: TransactionStore[];
@@ -81,11 +81,11 @@ export interface Transaction {
     stock_level_id: number | null;
     transaction_id: number | null;
   }>;
-  created_at: unknown;
-  updated_at: unknown;
+  created_at: FirestoreTimestampType;
+  updated_at: FirestoreTimestampType;
 }
 
-const TransactionStoreLocationSchema: z.ZodType<TransactionStoreLocation> = z.strictObject({
+export const TransactionStoreLocationSchema: z.ZodType<TransactionStoreLocation> = z.strictObject({
   uid_location: z.string(),
   name: z.string(),
   quantity: z.number(),
@@ -95,7 +95,7 @@ const TransactionStoreLocationSchema: z.ZodType<TransactionStoreLocation> = z.st
   max: z.number().nullable(),
 });
 
-const TransactionStoreSchema: z.ZodType<TransactionStore> = z.strictObject({
+export const TransactionStoreSchema: z.ZodType<TransactionStore> = z.strictObject({
   uid_store: z.string(),
   name: z.string(),
   default: z.boolean(),

--- a/src/typesense-config.ts
+++ b/src/typesense-config.ts
@@ -4,7 +4,7 @@
  * One doc per Typesense collection, tracks reindex state and schema hash.
  */
 import { z } from "zod";
-import { FirestoreTimestamp } from "./common.ts";
+import { FirestoreTimestamp, type FirestoreTimestampType } from "./common.ts";
 
 export interface TypesenseConfigReindexStats {
   total: number;
@@ -18,7 +18,7 @@ export interface TypesenseConfig {
   current_collection: string;
   schema_hash: string;
   updates: number;
-  last_reindex?: unknown;
+  last_reindex?: FirestoreTimestampType;
   last_reindex_stats?: TypesenseConfigReindexStats;
 }
 

--- a/src/user.ts
+++ b/src/user.ts
@@ -2,7 +2,7 @@
  * User document schema — Firestore collection: users
  */
 import { z } from "zod";
-import { Email, TimestampFields } from "./common.ts";
+import { Email, type FirestoreTimestampType, TimestampFields } from "./common.ts";
 
 /**
  * Full user document schema (Firestore document shape).
@@ -14,8 +14,8 @@ export interface User {
   email_verified: boolean;
   uid_customer?: string | null;
   roles?: string[];
-  created_at?: unknown;
-  updated_at?: unknown;
+  created_at?: FirestoreTimestampType;
+  updated_at?: FirestoreTimestampType;
 }
 
 export const UserSchema: z.ZodType<User> = z.strictObject({

--- a/src/webshop-product.ts
+++ b/src/webshop-product.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import {
   ComponentTypeEnum,
   type ComponentTypeType,
+  type FirestoreTimestampType,
   InclusionTypeEnum,
   type InclusionTypeType,
   PriceFormulaEnum,
@@ -81,8 +82,8 @@ export interface WebshopProduct {
     available: boolean;
     description?: string | null;
   };
-  created_at?: unknown;
-  updated_at?: unknown;
+  created_at?: FirestoreTimestampType;
+  updated_at?: FirestoreTimestampType;
 }
 
 const WebshopComponentSchema: z.ZodType<WebshopProductComponent> = z.strictObject({


### PR DESCRIPTION
…type safety

- FirestoreTimestampType: union of Timestamp, Date, plain object, and FieldValue
- Replace unknown timestamp fields with FirestoreTimestampType across all schemas
- Type product components, transaction stores, tag/TC count fields
- Export SchemaDocType union and sub-types (OrderDocDatesType, AddressType, etc.)
- Add SafeParseSchema type export for validate helpers