### PR TITLE
fix(order): use z.object() for input sub-schemas to strip extra fields

### DIFF
--- a/src/order.ts
+++ b/src/order.ts
@@ -50,7 +50,7 @@ export interface OrderDatesType {
   charge_end: string;
 }
 
-export const OrderDates: z.ZodType<OrderDatesType> = z.strictObject({
+export const OrderDates: z.ZodType<OrderDatesType> = z.object({
   delivery_start: z.string(),
   delivery_end: z.string(),
   collection_start: z.string(),
@@ -68,7 +68,7 @@ export interface DestinationContactType {
   phones?: string[];
 }
 
-export const DestinationContact: z.ZodType<DestinationContactType> = z.strictObject({
+export const DestinationContact: z.ZodType<DestinationContactType> = z.object({
   uid: z.string().optional(),
   name: z.string().optional(),
   phones: z.array(Phone).optional(),
@@ -99,7 +99,7 @@ export interface DestinationEndpointType {
   contact?: DestinationContactType | null;
 }
 
-export const DestinationEndpoint: z.ZodType<DestinationEndpointType> = z.strictObject({
+export const DestinationEndpoint: z.ZodType<DestinationEndpointType> = z.object({
   uid: z.string().nullable().optional(),
   address: Address.optional(),
   instructions: z.string().nullable().optional(),
@@ -133,7 +133,7 @@ export interface DestinationType {
   collection: DestinationEndpointType;
 }
 
-export const Destination: z.ZodType<DestinationType> = z.strictObject({
+export const Destination: z.ZodType<DestinationType> = z.object({
   delivery: DestinationEndpoint,
   collection: DestinationEndpoint,
 });
@@ -166,7 +166,7 @@ export interface ItemPriceType {
   total?: number;
 }
 
-export const ItemPrice: z.ZodType<ItemPriceType> = z.strictObject({
+export const ItemPrice: z.ZodType<ItemPriceType> = z.object({
   base: z.number().optional(),
   chargeable_days: z.int().nullable().optional(),
   discount_percent: z.number().optional(),
@@ -198,7 +198,7 @@ export interface OrderItemType {
   uid_order?: string;
 }
 
-export const OrderItem: z.ZodType<OrderItemType> = z.strictObject({
+export const OrderItem: z.ZodType<OrderItemType> = z.object({
   uid: z.string(),
   type: z.enum(ITEM_TYPES).optional(),
   name: z.string().optional(),

--- a/tests/order.test.ts
+++ b/tests/order.test.ts
@@ -67,7 +67,7 @@ Deno.test("CreateOrderInput rejects invalid tax_profile", () => {
   assertEquals(CreateOrderInput.safeParse(input).success, false);
 });
 
-Deno.test("CreateOrderInput rejects extra properties on dates", () => {
+Deno.test("CreateOrderInput strips extra properties on dates", () => {
   const input = {
     uid: "order-1",
     organization: { uid: "org-1" },
@@ -76,10 +76,14 @@ Deno.test("CreateOrderInput rejects extra properties on dates", () => {
     tax_profile: "tax_applied",
     destinations: [validDestination],
   };
-  assertEquals(CreateOrderInput.safeParse(input).success, false);
+  const result = CreateOrderInput.safeParse(input);
+  assertEquals(result.success, true);
+  if (result.success) {
+    assertEquals("extra_field" in result.data.dates, false);
+  }
 });
 
-Deno.test("CreateOrderInput rejects extra properties on destination endpoint", () => {
+Deno.test("CreateOrderInput strips extra properties on destination endpoint", () => {
   const input = {
     uid: "order-1",
     organization: { uid: "org-1" },
@@ -91,7 +95,11 @@ Deno.test("CreateOrderInput rejects extra properties on destination endpoint", (
       collection: { uid: "dest-2" },
     }],
   };
-  assertEquals(CreateOrderInput.safeParse(input).success, false);
+  const result = CreateOrderInput.safeParse(input);
+  assertEquals(result.success, true);
+  if (result.success) {
+    assertEquals("bonus" in result.data.destinations[0].delivery!, false);
+  }
 });
 
 Deno.test("CreateOrderInput rejects invalid item inclusion_type", () => {


### PR DESCRIPTION
Order input sub-schemas (OrderDates, OrderItem, ItemPrice, Destination, DestinationEndpoint, DestinationContact) were using z.strictObject() which rejects unknown keys. Changed to z.object() so extra fields like dates._fs timestamps and items[].crms_id are silently stripped on input. Document schemas remain strict for validateBeforeWrite safety.