### PR TITLE
Release schemas v8.1.0 (enable out-of-service Typesense alias)

### DIFF
--- a/src/typesense/out-of-service.ts
+++ b/src/typesense/out-of-service.ts
@@ -6,7 +6,7 @@ export const outOfService: TypesenseCollectionConfig = {
   version: 1,
   firestoreCollection: "out-of-service",
   collectionName: "out-of-service_v1",
-  enabled: false,
+  enabled: true,
   schema: {
     name: "out-of-service_v1",
     enable_nested_fields: true,


### PR DESCRIPTION
## Summary

Promotes the single beta-only commit to stable so utilities + api-cloudrun can pin off it without resorting to a downgrade-looking 7.0.0-beta.57.

- 79370e1 feat(typesense): enable out-of-service alias for syncing

## Why now

The /out-of-service route in manager (live as v6.0.0) renders "no permission to search this collection" because api-cloudrun cannot mint a scoped key for an alias that doesn't exist in Typesense. Flipping the schema flag is the prerequisite for the api startup reindex to create the alias and for `provision-typesense-search-keys.ts` to mint a parent key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)