### PR TITLE
Release schemas v8.2.0 (allow dates.start on UpdateOutOfServiceInput)

### DIFF
--- a/src/out-of-service.ts
+++ b/src/out-of-service.ts
@@ -275,11 +275,18 @@ export const CreateOutOfServiceInput: z.ZodType<CreateOutOfServiceInputType> = z
  * enforces `sum(breakdown) === quantity`. `status` is server-derived; only
  * `"canceled"` is honored from the client and translated into
  * `canceled_at = now()`.
+ *
+ * `dates.start` is honored on update only when the record has no sources
+ * (`sources.length === 0` — manually created / ad-hoc). Source-bound records
+ * (booking PUT or order check-in lineage) reject `dates.start` updates with a
+ * 400 — the start there reflects a real ledger event recorded by the upstream
+ * writer, and operator-side drift would desync the OOS from the source's
+ * audit trail.
  */
 export interface UpdateOutOfServiceInputType {
   status?: OOSStatusType;
   breakdown?: OOSBreakdown;
-  dates?: { end?: string | null };
+  dates?: { start?: string | null; end?: string | null };
   stores?: OOSStore[];
   version: number;
 }
@@ -289,6 +296,7 @@ export const UpdateOutOfServiceInput: z.ZodType<UpdateOutOfServiceInputType> = z
   status: OOSStatusEnum.optional(),
   breakdown: OOSBreakdownSchema.optional(),
   dates: z.object({
+    start: chicagoInstant().nullable().optional(),
     end: chicagoInstant().nullable().optional(),
   }).optional(),
   stores: z.array(OOSStoreSchema).optional(),


### PR DESCRIPTION
## Summary

Promotes the single beta-only commit to stable so utilities + api-cloudrun + manager can pin off it without resorting to a beta tag.

- fbca544 feat(oos): allow dates.start on UpdateOutOfServiceInput for ad-hoc records

## Why now

The new OOS detail page on manager (sitting locally on `cfs/manager` `main`, ready to deploy) lets operators create planned out-of-service records without a start time. Without this schema change there's no manager-side path to pin a start later — `UpdateOutOfServiceInput` only accepts `dates.end` today. This adds `dates.start` as optional; api-cloudrun enforces a source-bound lock (records with `sources.length > 0` reject `dates.start` updates with a 400) so booking/order-derived OOS records keep their pinned-by-source-event start.

## Test plan

- [ ] semantic-release publishes 8.2.0 to JSR after merge
- [ ] utilities-next deno.json schemas pin bump to 8.2.0 + lockstep republish
- [ ] api-cloudrun deno.json pin bump + writer extension + integration tests
- [ ] manager package.json caret already permits 8.2.0; gate-relax in OutOfServiceForm

🤖 Generated with [Claude Code](https://claude.com/claude-code)