### PR TITLE
feat(fulfillment): picker-editable line items + version + has_conflic…

### DIFF
--- a/src/fulfillment.ts
+++ b/src/fulfillment.ts
@@ -3,8 +3,13 @@
  *
  * Sanitized projection of an Order for the fulfillment client view.
  * Strips pricing, financial totals, invoice refs, tax profile, CRM/Xero
- * ids, version, notes, and transaction_fee line items. Keeps
- * destination contacts, dates, quantities, and item structure.
+ * ids, notes, and transaction_fee line items. Keeps destination contacts,
+ * dates, quantities, and item structure.
+ *
+ * Picker-editable: line items may carry `quantity_order` (server-set when
+ * picker quantity diverges from order quantity) and `path_substituted_for`
+ * (picker-set on substitution line items, cleared on graduation). The doc
+ * carries its own `version` for optimistic concurrency on picker writes.
  */
 import { z } from "zod";
 import {
@@ -44,6 +49,19 @@ export interface FulfillmentLineItemType {
   uid_order?: string;
   uid_delivery?: string | null;
   uid_collection?: string | null;
+  /**
+   * Server-set when picker quantity diverges from the order's projected
+   * quantity for the same path. Carries admin's intended quantity. Picker
+   * writes that include this field on any line item are rejected (400) —
+   * it is server-managed.
+   */
+  quantity_order?: number;
+  /**
+   * Picker-set on substitution line items. Carries the path of the
+   * substituted-for item at the moment of substitution. Cleared by the
+   * projection on graduation (admin emits at the same path).
+   */
+  path_substituted_for?: string[];
 }
 
 export const FulfillmentLineItem: z.ZodType<FulfillmentLineItemType> = z.strictObject({
@@ -58,6 +76,8 @@ export const FulfillmentLineItem: z.ZodType<FulfillmentLineItemType> = z.strictO
   uid_order: z.string().optional(),
   uid_delivery: z.string().nullable().optional(),
   uid_collection: z.string().nullable().optional(),
+  quantity_order: z.number().int().min(0).optional(),
+  path_substituted_for: z.array(z.string()).optional(),
 });
 
 /** Destination divider in the fulfillment items array. */
@@ -135,6 +155,13 @@ export interface Fulfillment {
   reference: string | null;
   query_by_items: string[];
   query_by_contacts: string[];
+  /**
+   * Optimistic-concurrency token. Bumped on every write — projection writes
+   * (createOrder, updateOrder, opportunity webhook) and picker writes (PUT
+   * /fulfillments/{uid}/items). Picker PUT body carries this value; server
+   * 409s on mismatch. Mirrors `Order.version`.
+   */
+  version: number;
   created_at?: FirestoreTimestampType;
   updated_at?: FirestoreTimestampType;
 }
@@ -151,6 +178,7 @@ export const FulfillmentSchema: z.ZodType<Fulfillment> = z.strictObject({
   reference: z.string().max(255).nullable().default(null),
   query_by_items: z.array(z.string()).default([]),
   query_by_contacts: z.array(z.string()).default([]),
+  version: z.int().min(0).default(0),
   ...TimestampFields,
 }).meta({
   title: "Fulfillment",

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -125,6 +125,8 @@ export const PERMISSIONS = [
   "ledgers.read",
   "fulfillment.read",
   "fulfillment.search",
+  "fulfillment.update",
+  "fulfillment.reset",
   "outOfService.create",
   "outOfService.read",
   "outOfService.update",

--- a/src/propagation/fulfillments.ts
+++ b/src/propagation/fulfillments.ts
@@ -1,0 +1,47 @@
+/**
+ * Fulfillment propagation rules — picker-driven edits to fulfillments/{uid}.
+ *
+ * Picker writes (PUT /fulfillments/{uid}/items, POST /fulfillments/{uid}/reset)
+ * mutate only the fulfillment doc itself. They do NOT cascade to bookings,
+ * stock-summaries, or inventory-ledgers — fulfillment is operational only;
+ * bookings/stock/ledger track the *promise*, not the *physical pick*. Drift
+ * between allocation and physical pick is an out-of-band reconciliation
+ * problem, not in scope here.
+ *
+ * Order-side projection writes to fulfillments (createOrder / updateOrder /
+ * opportunity webhook) live under the order rules — see `update-order:order-to-fulfillment`.
+ */
+import type { CollectionRule, TransactionDefinition } from "./types.ts";
+
+// ── update-fulfillment-items ─────────────────────────────────────────
+
+export const updateFulfillmentItemsRules: CollectionRule[] = [
+  {
+    id: "update-fulfillment-items:items-self",
+    source: "fulfillments",
+    target: "fulfillments",
+    mode: "co-write",
+    invariant:
+      "Picker writes mutate items + version + query_by_* on the same doc atomically. " +
+      "No cascade to bookings, stock-summaries, or inventory-ledgers — picker work is " +
+      "operational only and does not change the financial promise.",
+    transaction: "update-fulfillment-items",
+    fields: [
+      { source: ["items"], target: ["items"] },
+      { source: ["version"], target: ["version"], transform: "incremented" },
+      { source: [], target: ["query_by_items"], transform: "recomputed from merged items" },
+      { source: [], target: ["query_by_contacts"], transform: "recomputed from merged items" },
+    ],
+  },
+];
+
+export const updateFulfillmentItemsTransaction: TransactionDefinition = {
+  id: "update-fulfillment-items",
+  description:
+    "Picker write to a fulfillment's items. Validates against the underlying order " +
+    "and Product.alternates[], applies optimistic concurrency via version, and " +
+    "writes only the fulfillment doc itself — no cascade.",
+  steps: [
+    "update-fulfillment-items:items-self",
+  ],
+};

--- a/src/propagation/mod.ts
+++ b/src/propagation/mod.ts
@@ -100,6 +100,13 @@ export {
   updateOrderInvoiceRules,
 } from "./invoices.ts";
 
+// ── Fulfillment rules ───────────────────────────────────────────────
+
+export {
+  updateFulfillmentItemsRules,
+  updateFulfillmentItemsTransaction,
+} from "./fulfillments.ts";
+
 // ── Location rules ──────────────────────────────────────────────────
 
 export {
@@ -201,6 +208,7 @@ import { createContactRules, createContactTransaction, updateContactRules, updat
 import { createUserRules, createUserTransaction, updateUserRules, updateUserTransaction, deleteUserRules, deleteUserTransaction } from "./users.ts";
 import { createLocationRules, createLocationTransaction, updateLocationTransactionalRules, updateLocationTransaction } from "./locations.ts";
 import { createInvoiceRules, createInvoiceTransaction, updateInvoiceOrderRules, updateInvoiceTransaction, updateOrderInvoiceRules } from "./invoices.ts";
+import { updateFulfillmentItemsRules, updateFulfillmentItemsTransaction } from "./fulfillments.ts";
 import { updateTaxRules } from "./taxes.ts";
 import { updateTagRules, deleteTagRules, updateTrackingCategoryRules, updateLocationTypeRules, updateLocationRules } from "./reference-data.ts";
 import {
@@ -250,6 +258,7 @@ export const transactions: TransactionDefinition[] = [
   updateLocationTransaction,
   createInvoiceTransaction,
   updateInvoiceTransaction,
+  updateFulfillmentItemsTransaction,
   createRoleTransaction,
   createCommentTransaction,
   createCardTransaction,
@@ -287,6 +296,7 @@ export const rules: CollectionRule[] = [
   ...createInvoiceRules,
   ...updateInvoiceOrderRules,
   ...updateOrderInvoiceRules,
+  ...updateFulfillmentItemsRules,
   ...updateTaxRules,
   ...updateTagRules,
   ...deleteTagRules,

--- a/src/typesense/fulfillments.ts
+++ b/src/typesense/fulfillments.ts
@@ -12,11 +12,11 @@ import { typesenseAddressFields } from "./types.ts";
  */
 export const fulfillments: TypesenseCollectionConfig = {
   alias: "fulfillments",
-  version: 4,
+  version: 5,
   firestoreCollection: "fulfillments",
-  collectionName: "fulfillments_v4",
+  collectionName: "fulfillments_v5",
   schema: {
-    name: "fulfillments_v4",
+    name: "fulfillments_v5",
     enable_nested_fields: true,
     fields: [
       { name: "uid", type: "string", sort: true, facet: false },
@@ -25,6 +25,7 @@ export const fulfillments: TypesenseCollectionConfig = {
       { name: "status", type: "string", facet: true },
       { name: "deliveries", type: "bool", facet: true, optional: true },
       { name: "pickups", type: "bool", facet: true, optional: true },
+      { name: "has_conflicts", type: "bool", facet: true, optional: true },
       { name: "subject", type: "string", sort: true, stem: true, optional: true },
       { name: "reference", type: "string", stem: true, sort: true, optional: true },
       { name: "organization", type: "object" },

--- a/tests/propagation.test.ts
+++ b/tests/propagation.test.ts
@@ -70,6 +70,8 @@ import {
   createOutOfServiceTransaction,
   updateOutOfServiceRules,
   updateOutOfServiceTransaction,
+  updateFulfillmentItemsRules,
+  updateFulfillmentItemsTransaction,
 } from "../src/propagation/mod.ts";
 import { schemas } from "../src/mod.ts";
 
@@ -115,6 +117,7 @@ Deno.test("rules array contains all individual rule sets", () => {
     ...updateBookingRules,
     ...createOutOfServiceRules,
     ...updateOutOfServiceRules,
+    ...updateFulfillmentItemsRules,
   ];
   assertEquals(rules.length, allRuleSets.length);
   for (const rule of allRuleSets) {
@@ -174,6 +177,7 @@ Deno.test("transactions array contains all individual transactions", () => {
     bulkReturnOrderTransaction,
     createOutOfServiceTransaction,
     updateOutOfServiceTransaction,
+    updateFulfillmentItemsTransaction,
   ];
   assertEquals(transactions.length, allTransactions.length);
   for (const txn of allTransactions) {


### PR DESCRIPTION
…ts facet

Adds picker-write surface to fulfillments:
- FulfillmentLineItemType: optional `quantity_order` (server-set on conflict) and `path_substituted_for` (picker-set on substitution).
- Fulfillment: `version` for optimistic concurrency on picker writes.
- Typesense fulfillments_v5 with `has_conflicts` bool facet (derived in api-cloudrun coerceArrayFields).
- Permissions: `fulfillment.update`, `fulfillment.reset`.
- Propagation: `update-fulfillment-items` transaction (rule `update-fulfillment-items:items-self`) — co-write on the fulfillment doc only; no cascade to bookings/stock/ledger.